### PR TITLE
unixify ignore path for windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function(fileOrStream, opt){
   // Defaults:
   opt.starttag = opt.starttag || '<!-- inject:{{ext}} -->';
   opt.endtag = opt.endtag || '<!-- endinject -->';
-  opt.ignorePath = toArray(opt.ignorePath);
+  opt.ignorePath = toArray(opt.ignorePath).map(unixify);
   opt.addRootSlash = typeof opt.addRootSlash !== 'undefined' ? !!opt.addRootSlash : true;
   opt.transform = opt.transform || function (filepath) {
     switch(extname(filepath)) {


### PR DESCRIPTION
removeBasePath fails on a windows machine if ignorePath (unless a hard coded string) option is set due to backward slashes instead of forward slashes. Using the unixify function on the ignorePath array solves this.
