### PR TITLE
Allow protocol relative URLs with addPrefix

### DIFF
--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -202,7 +202,7 @@ function getFilepath (sourceFile, targetFile, opt) {
 
   if (opt.addRootSlash) {
     filepath = addRootSlash(filepath);
-  } else {
+  } else if(!opt.addPrefix) {
     filepath = removeRootSlash(filepath);
   }
 


### PR DESCRIPTION
By setting addRootSlash to false and setting addPrefix to something with a protocol relative URL, the prefix won't be clobbered by the addRootSlash function.

Closes #46 
