### PR TITLE
Prevent from grouping by extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ gulp.src('./bower.json')
   .pipe(inject(gulp.src(['./dist/app.min.js', './dist/app.min.css'], {read: false}), {
     starttag: '"main": [',
     endtag: ']',
+    ignoreExtensions: true,
     transform: function (filepath, file, i, length) {
       return '  "' + filepath + '"' + (i + 1 < length ? ',' : '');
     }
@@ -552,6 +553,14 @@ Default: `![options.relative](#optionsrelative)`
 
 
 The root slash is automatically added at the beginning of the path ('/'), or removed if set to `false`.
+
+#### options.ignoreExtensions
+Type: `Boolean`
+
+Default: `false`
+
+
+This prevents the source files from being grouped by extension.
 
 #### options.name
 Type: `String`

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -158,7 +158,7 @@ function getNewContent (target, collection, opt) {
   }
 
   var filesPerExtension = groupBy(collection, function (file) {
-    return extname(file.path);
+    return opt.ignoreExtensions ? '*' : extname(file.path);
   });
 
   var targetExt = extname(target.path);


### PR DESCRIPTION
This example taken from the README.md didn't work:

``` js
gulp.src('./bower.json')
  .pipe(inject(gulp.src(['./dist/app.min.js', './dist/app.min.css'], {read: false}), {
    starttag: '"main": [',
    endtag: ']',
    transform: function (filepath, file, i, length) {
      return '  "' + filepath + '"' + (i + 1 < length ? ',' : '');
    }
  }))
  .pipe(gulp.dest('./'));
```

It would only inject `app.min.css` since the injection of the CSS overwrites the injection of the JS.

I've added `ignoreExtensions` option to make it possible to inject all files regardless of their extension (could be useful in many situations I think).
