### PR TITLE
added a feature to read target after sources are generated

### DIFF
--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -50,8 +50,31 @@ describe('gulp-inject', function () {
     streamShouldContain(stream, ['defaults.html'], done);
   });
 
-  it('should inject sources into multiple targets', function (done) {
+  it('should inject stylesheets, scripts, images and html components even with read: false', function (done) {
+    var target = src(['template.html'], {read: false});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css',
+      'image.png',
+    ]);
 
+    var stream = target.pipe(inject(sources));
+
+    streamShouldContain(stream, ['defaults.html'], done);
+  });
+
+  it('should throw an error if lazy read failed', function(done) {
+    var target = src(['template.404.html'], {read: false});
+    var sources = src(['lib.js']);
+
+    target.pipe(inject(sources)).on('error', function(err) {
+      should(err.plugin).be.equal('gulp-inject');
+      done();
+    });
+  });
+
+  it('should inject sources into multiple targets', function (done) {
     var target = src(['template.html', 'template2.html'], {read: true});
     var sources = src([
       'lib.js',


### PR DESCRIPTION
Hi. If sources are generated for a while (coffee+lint+uglify), target.html could be changed between read and final write, so a result of gulp-inject() -> gulp.dest() will overwrite those changes and make some problems. 

This commit offer an solution to solve this problem:

``` javascript
gulp.src('./index.html', {read: false})
  .pipe(inject(slowTaskStream))
  .pipe(gulp.dest('./'))
```

So the content of index.html will be read just right before injection when slowTaskStream is ready and immediately written to disk, which decrease a possibility to get a corrupted content.

Also it's a good idea to recommend using this feature in docs.
