### PR TITLE
Added ability to remove tags after injection via options.removeTags

### DIFF
--- a/src/inject/expected/removeTags.html
+++ b/src/inject/expected/removeTags.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <link rel="import" href="/fixtures/component.html">
+  <link rel="stylesheet" href="/fixtures/styles.css">
+</head>
+<body>
+  <img src="/fixtures/image.png">
+
+  <script src="/fixtures/lib.js"></script>
+</body>
+</html>

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -183,7 +183,9 @@ function getNewContent (target, collection, opt) {
     return contents.replace(
       getInjectorTagsRegExp(startTag, endTag),
       function injector (match, starttag, indent, content, endtag) {
-        return [starttag]
+        var starttagArray = opt.removeTags ? [] : [starttag];
+        var endtagArray = opt.removeTags ? [] : [endtag];
+        return starttagArray
           .concat(files.reduce(function transformFile (lines, file, i) {
             var filepath = getFilepath(file, target, opt);
             var transformedContents = opt.transform(filepath, file, i, files.length, target);
@@ -192,7 +194,7 @@ function getNewContent (target, collection, opt) {
             }
             return lines.concat(transformedContents.split(/\r?\n/g));
           }, []))
-          .concat([endtag])
+          .concat(endtagArray)
           .join(indent);
       }
     );

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -333,6 +333,20 @@ describe('gulp-inject', function () {
     streamShouldContain(stream, ['issue74.html'], done);
   });
 
+  it('should be able to remove tags if option present', function (done) {
+    var target = src(['template.html'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css',
+      'image.png',
+    ]);
+
+    var stream = target.pipe(inject(sources,{removeTags:true}));
+
+    streamShouldContain(stream, ['removeTags.html'], done);
+  });
+
 });
 
 function src (files, opt) {


### PR DESCRIPTION
usage:

```
target.pipe(inject(sources, { removeTags: true }))
      .pipe(gulp.dest("dest"));
```