### PR TITLE
Add "quiet" option to suppress log output

### DIFF
--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -42,6 +42,7 @@ module.exports = exports = function(sources, opt){
   }
 
   // Defaults:
+  opt.quiet = bool(opt, 'quiet', false);
   opt.ignorePath = toArray(opt.ignorePath).map(unixify);
   opt.relative = bool(opt, 'relative', false);
   opt.addRootSlash = bool(opt, 'addRootSlash', !opt.relative);
@@ -154,7 +155,9 @@ function collector (collection, opt) {
 function getNewContent (target, collection, opt) {
   var oldContent = target.contents;
   if (!collection.length) {
-    log('Nothing to inject into ' + magenta(target.relative) + '.');
+    if (!opt.quiet) {
+      log('Nothing to inject into ' + magenta(target.relative) + '.');
+    }
     return oldContent;
   }
   var tags = {};
@@ -173,7 +176,9 @@ function getNewContent (target, collection, opt) {
 
   var startAndEndTags = Object.keys(filesPerTags);
 
-  log(cyan(collection.length) + ' files into ' + magenta(target.relative) + '.');
+  if (!opt.quiet) {
+    log(cyan(collection.length) + ' files into ' + magenta(target.relative) + '.');
+  }
 
   return new Buffer(startAndEndTags.reduce(function eachInCollection (contents, tag) {
     var files = filesPerTags[tag];

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -1,4 +1,4 @@
-/*global describe, it*/
+/*global describe, it, beforeEach, afterEach*/
 'use strict';
 
 var fs = require('fs'),
@@ -10,6 +10,16 @@ var gutil = require('gulp-util'),
   inject = require('./');
 
 describe('gulp-inject', function () {
+  var log;
+
+  beforeEach(function () {
+    log = gutil.log;
+  });
+
+  afterEach(function () {
+    gutil.log = log;
+  });
+
   it('should throw an error when the old api with target as string is used', function () {
     should(function () {
       var stream = inject('fixtures/template.html');
@@ -347,6 +357,49 @@ describe('gulp-inject', function () {
     streamShouldContain(stream, ['removeTags.html'], done);
   });
 
+  it('should not produce log output if quiet option is set', function (done) {
+    var logOutput = [];
+    gutil.log = function () {
+      logOutput.push(arguments);
+    };
+
+    var target = src(['template.html'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css',
+      'image.png'
+    ]);
+
+    var stream = target.pipe(inject(sources, {quiet: true}));
+
+    stream.on('end', function () {
+      logOutput.should.have.length(0);
+      done();
+    });
+  });
+
+  it('should produce log output if quiet option is not set', function (done) {
+    var logOutput = [];
+    gutil.log = function () {
+      logOutput.push(arguments);
+    };
+
+    var target = src(['template.html'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css',
+      'image.png'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    stream.on('end', function () {
+      logOutput.should.have.length(1);
+      done();
+    });
+  });
 });
 
 function src (files, opt) {


### PR DESCRIPTION
I use gulp-inject as part of a dev server in a number of projects, and the log messages get pretty noisy. This adds a "quiet" option that suppresses info-level log messages (warnings and errors are unaffected).