### PR TITLE
Add a 'quiet' option to mute console log of successful injections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,13 @@ Default: `"inject"`
 
 Used in the default [start](#optionsstarttag) and [end](#optionsendtag) tags below.
 
+#### options.quiet
+Type: `Boolean`
+
+Default: `false`
+
+Run in quiet mode, without printing the log of successful injections.
+
 
 #### options.starttag
 

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -172,8 +172,10 @@ function getNewContent (target, collection, opt) {
   });
 
   var startAndEndTags = Object.keys(filesPerTags);
-
-  log(cyan(collection.length) + ' files into ' + magenta(target.relative) + '.');
+  
+  if(!opt.quiet) {
+    log(cyan(collection.length) + ' files into ' + magenta(target.relative) + '.');
+  }
 
   return new Buffer(startAndEndTags.reduce(function eachInCollection (contents, tag) {
     var files = filesPerTags[tag];


### PR DESCRIPTION
console log of successful injections is verbose。