### PR TITLE
addSuffix feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,14 @@ Default: `NULL`
 
 A path that should be prefixed to each injected file path.
 
+#### options.addSuffix
+Type: `String`
+
+Default: `NULL`
+
+
+A path that should be suffixed to each injected file path.
+
 #### options.addRootSlash
 Type: `Boolean`
 
@@ -631,7 +639,7 @@ A function dependent on target file type and source file type that returns:
 **Type**: `Function(filepath, file, index, length, targetFile)`
 
 **Params:**
-  - `filepath` - The "unixified" path to the file with any `ignorePath`'s removed and `addPrefix` added
+  - `filepath` - The "unixified" path to the file with any `ignorePath`'s removed, `addPrefix` and `addSuffix` added
   - `file` - The [File object](https://github.com/wearefractal/vinyl) to inject given from `gulp.src`
   - `index` - 0-based file index
   - `length` - Total number of files to inject for the current file extension

--- a/src/inject/expected/addSuffix.html
+++ b/src/inject/expected/addSuffix.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- inject:html -->
+  <link rel="import" href="fixtures/component.html?my-test=suffix">
+  <!-- endinject -->
+  <!-- inject:css -->
+  <link rel="stylesheet" href="fixtures/styles.css?my-test=suffix">
+  <!-- endinject -->
+</head>
+<body>
+  <!-- inject:png -->
+  <!-- endinject -->
+
+  <!-- inject:js -->
+  <script src="fixtures/lib.js?my-test=suffix"></script>
+  <script src="fixtures/lib2.js?my-test=suffix"></script>
+  <!-- endinject -->
+
+  <!-- inject:jsx -->
+  <script type="text/jsx" src="fixtures/lib.jsx?my-test=suffix"></script>
+  <!-- endinject -->
+</body>
+</html>

--- a/src/inject/expected/addSuffix.html
+++ b/src/inject/expected/addSuffix.html
@@ -3,10 +3,10 @@
 <head>
   <title>gulp-inject</title>
   <!-- inject:html -->
-  <link rel="import" href="fixtures/component.html?my-test=suffix">
+  <link rel="import" href="/fixtures/component.html?my-test=suffix">
   <!-- endinject -->
   <!-- inject:css -->
-  <link rel="stylesheet" href="fixtures/styles.css?my-test=suffix">
+  <link rel="stylesheet" href="/fixtures/styles.css?my-test=suffix">
   <!-- endinject -->
 </head>
 <body>
@@ -14,12 +14,12 @@
   <!-- endinject -->
 
   <!-- inject:js -->
-  <script src="fixtures/lib.js?my-test=suffix"></script>
-  <script src="fixtures/lib2.js?my-test=suffix"></script>
+  <script src="/fixtures/lib.js?my-test=suffix"></script>
+  <script src="/fixtures/lib2.js?my-test=suffix"></script>
   <!-- endinject -->
 
   <!-- inject:jsx -->
-  <script type="text/jsx" src="fixtures/lib.jsx?my-test=suffix"></script>
+  <script type="text/jsx" src="/fixtures/lib.jsx?my-test=suffix"></script>
   <!-- endinject -->
 </body>
 </html>

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -224,6 +224,10 @@ function getFilepath (sourceFile, targetFile, opt) {
   } else if(!opt.addPrefix) {
     filepath = removeRootSlash(filepath);
   }
+  
+  if (opt.addSuffix) {
+    filepath = addSuffix(filepath, opt.addSuffix);
+  }
 
   return filepath;
 }
@@ -255,6 +259,9 @@ function removeRootSlash (filepath) {
 }
 function addPrefix (filepath, prefix) {
   return  prefix + addRootSlash(filepath);
+}
+function addSuffix (filepath, suffix) {
+  return  filepath + suffix;
 }
 
 function removeBasePath (basedir, filepath) {

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -121,6 +121,21 @@ describe('gulp-inject', function () {
 
     streamShouldContain(stream, ['addPrefix.html'], done);
   });
+  
+  it('should inject stylesheets, scripts and html components with `addSuffix` added to file path', function (done) {
+    var target = src(['template.html'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'lib2.js',
+      'styles.css',
+      'lib.jsx'
+    ]);
+
+    var stream = target.pipe(inject(sources, {addSuffix: '?my-test=suffix'}));
+
+    streamShouldContain(stream, ['addSuffix.html'], done);
+  });
 
   it('should inject stylesheets and html components with self closing tags if `selfClosingTag` is truthy', function (done) {
     var target = src(['template.html'], {read: true});


### PR DESCRIPTION
Add `addSuffix` option, please.

Sometimes we need to inject files with query parameters. Something like:
``` javascript
<script src="some/path/file.js?ver=1.2.2"></script>
```
`addSuffix` option will allow that case.