### PR TITLE
Add tests for node 0.12 and iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: node_js
 node_js:
   - '0.10'
   - '0.11'
+  - '0.12'
+  - 'iojs'
+
+sudo: false


### PR DESCRIPTION
Add node 0.12 and iojs for testing, with [container-based environment](http://docs.travis-ci.com/user/ci-environment/#Virtualization-environments) which is slightly faster.