### PR TITLE
fixed link to from addRootSlash to relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,7 +574,7 @@ A path that should be suffixed to each injected file path.
 #### options.addRootSlash
 Type: `Boolean`
 
-Default: `![options.relative](#optionsrelative)`
+Default: [`!options.relative`](#optionsrelative)
 
 
 The root slash is automatically added at the beginning of the path ('/'), or removed if set to `false`.


### PR DESCRIPTION
A small change to the readme. It seems links are not supported within code blocks, this change puts the link around the inline code block.