### PR TITLE
dynamic fillers for large apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -523,6 +523,75 @@ And in your `./src/index.html`:
 </body>
 </html>
 ```
+### Injecting with dynamic custom `transform` function
+
+The [default `transform`](#injecttransform) function is available to use e.g. as a default fallback.
+
+Used here to inject Word documents as `<a>` tags below:
+
+**`index.html`:**
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My documents</title>
+</head>
+<body>
+  <h1>Documents</h1>
+  <!-- module:main:js -->
+  <!-- endinject -->
+  <!-- module:messaging:js -->
+  <!-- endinject -->
+  <!-- module:somethingelse:js -->
+  <!-- endinject -->
+</body>
+</html>
+```
+
+**`gulpfile.js`:**
+
+```javascript
+var inject = require('gulp-inject');
+
+gulp.src('./index.html')
+  .pipe(inject(
+    // note the :: that mark a dynamic tag name
+    gulp.src(['./app/**/*.js'], {name:'module::',read: false}), {
+      transform: function (filepath, file, i, length, target, tagname) {
+          // tagname is the full tag name, for instance: module:main:js
+          var filter = /:(.+):/.exec(tagname)[1];
+          if (filepath.split('/').indexOf(filter) === 1){
+            return $.inject.transform.apply($.inject.transform, arguments);
+          }
+      }
+    }
+  ))
+  .pipe(gulp.dest('./'));
+```
+
+**Resulting `index.html`:**
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My documents</title>
+</head>
+<body>
+  <h1>Documents</h1>
+  <!-- module:main:js -->
+  <!-- only the files found in app/main/*.js -->
+  <!-- endinject -->
+  <!-- module:messaging:js -->
+  <!-- only the files found in app/messaging/*.js -->
+  <!-- endinject -->
+  <!-- module:somethingelse:js -->
+  <!-- only the files found in app/somethingelse/*.js -->
+  <!-- endinject -->
+</body>
+</html>
+```
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -525,9 +525,9 @@ And in your `./src/index.html`:
 ```
 ### Injecting with dynamic custom `transform` function
 
-The [default `transform`](#injecttransform) function is available to use e.g. as a default fallback.
+You can make use of dynamic fillers `::` to inject content dynamically using `transform` function.
 
-Used here to inject Word documents as `<a>` tags below:
+Here is an example for a big application that requires selective modules injections :
 
 **`index.html`:**
 

--- a/src/inject/expected/customFillInName.html
+++ b/src/inject/expected/customFillInName.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- file:main:js -->
+  <script src="/fixtures/lib.js"></script>
+  <script src="/fixtures/lib2.js"></script>
+  <!-- endinject -->
+</head>
+<body>
+
+</body>
+</html>

--- a/src/inject/expected/customFillInTags.html
+++ b/src/inject/expected/customFillInTags.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- custom:dir -->
+  <script src="/lib.js"></script>
+  <script src="/lib2.js"></script>
+  <link rel="stylesheet" href="/style.css">
+  <!-- endcustom -->
+</head>
+<body>
+
+</body>
+</html>

--- a/src/inject/fixtures/templateCustomFillInName.html
+++ b/src/inject/fixtures/templateCustomFillInName.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- file:main:js -->
+  <!-- endinject -->
+</head>
+<body>
+
+</body>
+</html>

--- a/src/inject/fixtures/templateCustomFillInTags.html
+++ b/src/inject/fixtures/templateCustomFillInTags.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- custom:dir -->
+  <!-- endcustom -->
+</head>
+<body>
+
+</body>
+</html>

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -189,12 +189,13 @@ function getNewContent (target, collection, opt) {
       getInjectorTagsRegExp(startTag, endTag),
       function injector (match, starttag, indent, content, endtag) {
         matches.push(starttag);
+        var tagName = extractTagName(starttag);
         var starttagArray = opt.removeTags ? [] : [starttag];
         var endtagArray = opt.removeTags ? [] : [endtag];
         return starttagArray
           .concat(files.reduce(function transformFile (lines, file, i) {
             var filepath = getFilepath(file, target, opt);
-            var transformedContents = opt.transform(filepath, file, i, files.length, target);
+            var transformedContents = opt.transform(filepath, file, i, files.length, target, tagName);
             if (typeof transformedContents !== 'string') {
               return lines;
             }
@@ -267,7 +268,7 @@ function makeWhiteSpaceOptional (str) {
 }
 
 function escapeForRegExp (str) {
-  return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+  return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&').replace(/::/, ':.*');
 }
 
 function unixify (filepath) {
@@ -330,4 +331,15 @@ function warn (message) {
 
 function error (message) {
   return new PluginError(PLUGIN_NAME, message);
+}
+
+function extractTagName(tag) {
+  var tagName = tag;
+  var l = (tag.match(/\s/g)||[]).length;
+  if (l === 1) {
+      tagName = /\s(.+)/.exec(tag)[1];
+  } else if (l >= 2) {
+      tagName = /\s(.+)\s/.exec(tag)[1];
+  }
+  return tagName;
 }

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -547,6 +547,35 @@ describe('gulp-inject', function () {
 
     streamShouldContain(stream, ['removeAndEmptyTags.html'], done);
   });
+
+  it('should use starttag and endtag with dynamic names specified name if specified', function (done) {
+    var target = src(['templateCustomFillInName.html'], {read: true});
+    var sources = src([
+      'lib.js',
+      'lib2.js'
+    ]);
+
+    var stream = target.pipe(inject(sources, {name: 'file::'}));
+
+    streamShouldContain(stream, ['customFillInName.html'], done);
+  });
+
+  it('should use starttag and endtag if specified', function (done) {
+    var target = src(['templateCustomFillInTags.html'], {read: true});
+    var sources = src([
+      'lib.js',
+      'lib2.js',
+      'style.css'
+    ]);
+
+    var stream = target.pipe(inject(sources, {
+      ignorePath: 'fixtures',
+      starttag: '<!-- custom:: -->',
+      endtag: '<!-- endcustom -->'
+    }));
+
+    streamShouldContain(stream, ['customFillInTags.html'], done);
+  });
 });
 
 function src (files, opt) {

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -11,7 +11,7 @@ var DEFAULT_TARGET = TARGET_TYPES[0];
 /**
  * Transform module
  */
-var transform = module.exports = exports = function (filepath, i, length, sourceFile, targetFile) {
+var transform = module.exports = exports = function (filepath, i, length, sourceFile, targetFile, tagName) {
   var type;
   if (targetFile && targetFile.path) {
     var ext = extname(targetFile.path);


### PR DESCRIPTION
This pull request is made in regards of issue #80 which is also something that we needed and which should resolves all cases.

It allows to set a dynamic filler such as `name:'module::'`
and in the page have injections like : `<!-- module:main:js --><!-- module:other:js -->`
the transforms methods now returns the tag name as found in the html page giving freedom to apply specific injection rules.

I have added some tests and updated also the documentation.
Hopes this helps and can be integrated soon.