### PR TITLE
Fix for #156

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-inject",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A javascript, stylesheet and webcomponent injection plugin for Gulp, i.e. inject file references into your index.html",
   "keywords": [
     "gulpplugin",

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -194,7 +194,7 @@ function getNewContent (target, collection, opt) {
         return starttagArray
           .concat(files.reduce(function transformFile (lines, file, i) {
             var filepath = getFilepath(file, target, opt);
-            var transformedContents = opt.transform(filepath, file, i, files.length, target);
+            var transformedContents = opt.transform(filepath, extname(file.path), file, i, files.length, target);
             if (typeof transformedContents !== 'string') {
               return lines;
             }

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -11,11 +11,10 @@ var DEFAULT_TARGET = TARGET_TYPES[0];
 /**
  * Transform module
  */
-var transform = module.exports = exports = function (filepath, i, length, sourceFile, targetFile) {
+var transform = module.exports = exports = function (filepath, ext, i, length, sourceFile, targetFile) {
   var type;
   if (targetFile && targetFile.path) {
-    var ext = extname(targetFile.path);
-    type = typeFromExt(ext);
+    type = typeFromExt(extname(targetFile.path));
   }
   if (!isTargetType(type)) {
     type = DEFAULT_TARGET;
@@ -36,8 +35,7 @@ transform.selfClosingTag = false;
  * Transform functions
  */
 TARGET_TYPES.forEach(function (targetType) {
-  transform[targetType] = function (filepath) {
-    var ext = extname(filepath);
+  transform[targetType] = function (filepath, ext) {
     var type = typeFromExt(ext);
     var func = transform[targetType][type];
     if (func) {


### PR DESCRIPTION
Rather than using the `getFilepath`'d filename to get the extension, I use the original path and pass the extension directly into the transform constructor.