### PR TITLE
Add {{path}} parsing to 'start-' and 'endtag'

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,13 +621,14 @@ When `true` all tags without corresponding files will be emptied.
 **Purpose:**
 
 Used to dynamically set starting placeholder tag depending on file extensions.
-In the provided string, or the string returned from the given function, the string `{{ext}}` is replaced with the source file extension name, e.g. "css", "js" or "html". `{{name}}` will be replaced by [`options.name`](#optionsname).
+In the provided string, or the string returned from the given function, the string `{{ext}}` is replaced with the source file extension name, e.g. "css", "js" or "html". `{{name}}` will be replaced by [`options.name`](#optionsname). `{{path}}` will be replaced by path to source file (when used together with `relative: true` it's relative path to file.
 
 ##### Default:
 
 A function dependent on target file type and source file type that returns:
 
 * html as target: `<!-- {{name}}:{{ext}} -->`
+* html as path: `<!-- {{path}} -->`
 * haml as target: `-# {{name}}:{{ext}}`
 * jade as target: `//- {{name}}:{{ext}}`
 * jsx as target: `{/* {{name}}:{{ext}} */}`
@@ -646,7 +647,7 @@ A function dependent on target file type and source file type that returns:
 **Purpose:**
 
 Used to dynamically set ending placeholder tag depending on file extensions.
-In the provided string, or the string returned from the given function, the string `{{ext}}` is replaced with the source file extension name, e.g. "css", "js" or "html". `{{name}}` will be replaced by [`options.name`](#optionsname).
+In the provided string, or the string returned from the given function, the string `{{ext}}` is replaced with the source file extension name, e.g. "css", "js" or "html". `{{name}}` will be replaced by [`options.name`](#optionsname). `{{path}}` will be replaced by path to source file.
 
 ##### Default:
 

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ And in your `./src/index.html`:
 
 ### Injecting files contents based on file path
 
-In order to inject files based on file path you have to provide custom `starttag` which includes `{{path}}`. Additionally, in order to inject file contents include `transform` function, that will return file contents as string. You also have to omit `{read: false}` option of `gulp.src` in this case. Path can be either absolute, or relative in which case you should use `relative:true`. Example below shows how to inject contents of html partials into `index.html`:
+In order to inject files based on file path you have to provide custom `starttag` which includes `{{path}}`. Additionally, in order to inject file contents include `transform` function, that will return file contents as string. You also have to omit `{read: false}` option of `gulp.src` in this case. Path can be either absolute, or relative in which case you should set [`options.relative`] to true. Example below shows how to inject contents of html partials into `index.html`:
 
 ***Code:***
 

--- a/README.md
+++ b/README.md
@@ -528,6 +528,41 @@ And in your `./src/index.html`:
 </html>
 ```
 
+### Injecting files contents based on file path
+
+In order to inject files based on file path you have to provide custom `starttag` which includes `{{path}}`. Additionally, in order to inject file contents include `transform` function, that will return file contents as string. You also have to omit `{read: false}` option of `gulp.src` in this case. Path can be either absolute, or relative in which case you should use `relative:true`. Example below shows how to inject contents of html partials into `index.html`:
+
+***Code:***
+
+```javascript
+gulp.src('./src/index.html')
+  .pipe(inject(gulp.src(['./src/partials/head/*.html']), {
+    starttag: '<!-- inject:{{path}} -->',
+    relative: true,
+    transform: function (filePath, file) {
+      // return file contents as string
+      return file.contents.toString('utf8')
+    }
+  }))
+  .pipe(gulp.dest('./dest'));
+```
+
+And in your `./src/index.html`:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My index</title>
+  <!-- inject:path/to/your/file.ext -->
+  <!-- contents of html partials will be injected here -->
+  <!-- endinject -->
+</head>
+<body>
+</body>
+</html>
+```
+
 ## API
 
 ### inject(sources, options)
@@ -621,14 +656,13 @@ When `true` all tags without corresponding files will be emptied.
 **Purpose:**
 
 Used to dynamically set starting placeholder tag depending on file extensions.
-In the provided string, or the string returned from the given function, the string `{{ext}}` is replaced with the source file extension name, e.g. "css", "js" or "html". `{{name}}` will be replaced by [`options.name`](#optionsname). `{{path}}` will be replaced by path to source file (when used together with `relative: true` it's relative path to file.
+In the provided string, or the string returned from the given function, the string `{{ext}}` is replaced with the source file extension name, e.g. "css", "js" or "html". `{{name}}` will be replaced by [`options.name`](#optionsname). `{{path}}` will be replaced by path to source file (when used together with [`options.relative`] it will allow relative path to source file.
 
 ##### Default:
 
 A function dependent on target file type and source file type that returns:
 
 * html as target: `<!-- {{name}}:{{ext}} -->`
-* html as path: `<!-- {{path}} -->`
 * haml as target: `-# {{name}}:{{ext}}`
 * jade as target: `//- {{name}}:{{ext}}`
 * jsx as target: `{/* {{name}}:{{ext}} */}`

--- a/src/inject/expected/customTagsWithPath.html
+++ b/src/inject/expected/customTagsWithPath.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><!-- /fixtures/partial.html: --><div>Partial body</div><!-- :/fixtures/partial.html --><h1>Hello world</h1>

--- a/src/inject/fixtures/partial.html
+++ b/src/inject/fixtures/partial.html
@@ -1,0 +1,1 @@
+<div>Partial body</div>

--- a/src/inject/fixtures/templateTagsWithPath.html
+++ b/src/inject/fixtures/templateTagsWithPath.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><!-- /fixtures/partial.html: --><!-- :/fixtures/partial.html --><h1>Hello world</h1>

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -112,7 +112,7 @@ function getNewContent(target, collection, opt) {
   }
   var content = String(target.contents);
   var targetExt = extname(target.path);
-  var files = prepareFiles(collection, targetExt, opt);
+  var files = prepareFiles(collection, targetExt, opt, target);
   var filesPerTags = groupArray(files, 'tagKey');
   var startAndEndTags = Object.keys(filesPerTags);
   var matches = [];
@@ -219,11 +219,12 @@ function getLeadingWhitespace(str) {
   return str.match(LEADING_WHITESPACE_REGEXP)[0];
 }
 
-function prepareFiles(files, targetExt, opt) {
+function prepareFiles(files, targetExt, opt, target) {
   return files.map(function (file) {
     var ext = extname(file.path);
-    var startTag = getTagRegExp(opt.tags.start(targetExt, ext, opt.starttag), ext, opt);
-    var endTag = getTagRegExp(opt.tags.end(targetExt, ext, opt.endtag), ext, opt);
+    var filePath = getFilepath(file, target, opt);
+    var startTag = getTagRegExp(opt.tags.start(targetExt, ext, opt.starttag), ext, opt, filePath);
+    var endTag = getTagRegExp(opt.tags.end(targetExt, ext, opt.endtag), ext, opt, filePath);
     var tagKey = String(startTag) + String(endTag);
     return {
       file,
@@ -235,10 +236,11 @@ function prepareFiles(files, targetExt, opt) {
   });
 }
 
-function getTagRegExp(tag, sourceExt, opt) {
+function getTagRegExp(tag, sourceExt, opt, sourcePath) {
   tag = makeWhiteSpaceOptional(escapeStringRegexp(tag));
   tag = replaceVariables(tag, {
     name: opt.name,
+    path: sourcePath,
     ext: sourceExt === '{{ANY}}' ? '.+' : sourceExt
   });
   return new RegExp(tag, 'ig');

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -221,6 +221,25 @@ describe('gulp-inject', function () {
     streamShouldContain(stream, ['customTagsWithExt.html'], done);
   });
 
+  it('should replace {{path}} in starttag and endtag with current file path if specified', function (done) {
+    var target = src(['templateTagsWithPath.html'], {read: true});
+    var sources = src([
+      'template.html',
+      'partial.html',
+      'template2.html'
+    ], {read: true});
+
+    var stream = target.pipe(inject(sources, {
+      starttag: '<!-- {{path}}: -->',
+      endtag: '<!-- :{{path}} -->',
+      transform: function (filePath, file) {
+        return file.contents.toString('utf8');
+      }
+    }));
+
+    streamShouldContain(stream, ['customTagsWithPath.html'], done);
+  });
+
   it('should replace existing data within start and end tag', function (done) {
     var target = src(['templateWithExistingData.html'], {read: true});
     var sources = src([


### PR DESCRIPTION
Now we can target specific files to inject based on their file path.
Works in alignment with 'relative' param to detect relative path from destination file.

This was added for easier partials loading in big application, with avoiding the need to have complex config structures.
