### PR TITLE
Added new option: attributes which are embedded in html tags

### DIFF
--- a/src/attrString/attrString_test.js
+++ b/src/attrString/attrString_test.js
@@ -1,0 +1,83 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks:[1, 5] */
+'use strict';
+var should = require('should');
+
+describe('attrString', function () {
+  var tags;
+  var attrStringModule;
+
+  it('should not crash when required', function () {
+    should(function () {
+      attrStringModule = require('./');
+    }).not.throw();
+  });
+
+  it('should be a function', function () {
+    attrStringModule.should.be.type('function');
+  });
+
+  describe('with parameter', function () {
+    it('string', function(){
+	  attrStringModule('test').should.equal(' test');
+	});
+	  
+	it('number', function(){
+	  should(function(){
+	    attrStringModule(12);
+	  }).throw();
+	});
+	
+	it('function', function(){
+	  should(function(){
+	    attrStringModule(function(){});
+	  }).throw();
+	});
+  
+	it('undefined', function(){
+	  attrStringModule().should.equal('');
+	});
+	  
+	it('valid object', function(){
+	  attrStringModule({a: 'A', b: 'B'}).should.equal(' a="A" b="B"');
+	});
+	  
+	it('invalid object', function(){
+	  should(function(){
+	    attrStringModule({a:{}});
+	  }).throw();
+	});
+	  
+	describe('array', function(){
+	  it('empty', function(){
+	    attrStringModule([]).should.equal('');
+	  });
+		
+	  it('strings', function(){
+	    attrStringModule(['a', 'b']).should.equal(' a b');
+	  });
+		
+	  it('number', function(){
+	    should(function(){
+	      attrStringModule([12]).should.trow();
+	    }).throw();
+	  });
+	
+	  it('function', function(){
+	    should(function(){
+	      attrStringModule([function(){}]);
+	    }).throw();
+	  });
+		
+	  it('objects', function(){
+	    attrStringModule([{name: 'a', value:'A'}, {name: 'b', value:'B'}]).should.equal(' a="A" b="B"');
+	  });
+		
+	  it('arrays', function(){
+	    attrStringModule([['a', 'A'],['b', 'B']]).should.equal(' a="A" b="B"');
+	  });
+	});
+	  
+  });
+});
+

--- a/src/attrString/index.js
+++ b/src/attrString/index.js
@@ -1,0 +1,75 @@
+'use strict'
+
+var gutil = require('gulp-util');
+
+var PluginError = gutil.PluginError;
+
+/**
+ * Constants
+ */
+var PLUGIN_NAME = 'gulp-inject';
+
+module.exports = exports = function attrString(attributes) {
+  
+  if(!attributes)
+	  return '';
+
+  if(typeof attributes === 'string')
+	  return ' ' + attributes;
+	
+  if(typeof attributes !== 'object')
+	  throw error('`' + (typeof attributes) + '` is not a valid type for attributes!');
+ 
+  var result = ' ';
+  var first = true;
+  if(Array.isArray(attributes)){
+	if(attributes.length === 0)
+	  return '';
+    for(var i =0; i < attributes.length; i++){
+	  result = result + (first? '' : ' ') + attrObjToString(attributes[i]);
+	  first = false;
+	}
+  }
+  else{
+    for (var key in attributes) {
+	  if (attributes.hasOwnProperty(key)) {
+		if(typeof attributes[key] !== 'string')
+		  throw error('The type of the attribute `' + key + '` must be a string and not a ' + (typeof attributes[key]) + ' !' );
+	    result = result + (first? '' : ' ') + key + '="' + attributes[key] + '"';
+	    first = false;
+	  }
+	}
+  }
+	
+  return result;
+};
+
+function attrObjToString(attribute){
+  if(typeof attribute === 'string')
+    return attribute;
+  if(typeof attribute === 'object')
+  {
+    if(Array.isArray(attribute)){
+	  if(attribute.length === 2)
+	    return attribute[0] + '="' + attribute[1] + '"';
+	  else if(attribute.length === 1)
+	    return attribute[0];
+	  else
+	    throw error('If an attribute is an array, it must contain one or two elements ([name, value]) and not ' + attribute.length + ' !');
+	}
+	else{
+	  if(!attribute.hasOwnProperty('name'))
+	    error('An attribute object must have an property named `name`!');
+	  if(!attribute.hasOwnProperty('value'))
+	    error('An attribute object must have an property named `value`!');
+	  return attribute.name + '="' + attribute.value + '"';
+	}
+	
+  }
+  throw error('`' + (typeof attribute) + '` is not a valid type for an attribute!');
+}
+
+
+function error(message) {
+  return new PluginError(PLUGIN_NAME, message);
+}

--- a/src/inject/expected/attributes.html
+++ b/src/inject/expected/attributes.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- inject:html -->
+  <!-- endinject -->
+  <!-- inject:css -->
+  <link rel="stylesheet" href="/fixtures/styles.css" test>
+  <!-- endinject -->
+</head>
+<body>
+  <!-- inject:png -->
+  <!-- endinject -->
+
+  <!-- inject:js -->
+  <script src="/fixtures/lib.js" test></script>
+  <!-- endinject -->
+
+  <!-- inject:jsx -->
+  <!-- endinject -->
+</body>
+</html>

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -50,6 +50,8 @@ module.exports = exports = function (sources, opt) {
   opt.transform = defaults(opt, 'transform', transform);
   opt.tags = tags();
   opt.name = defaults(opt, 'name', DEFAULT_NAME_FOR_TAGS);
+  opt.attributes = defaults(opt, 'attributes', []);
+  
   transform.selfClosingTag = bool(opt, 'selfClosingTag', false);
 
   // Is the first parameter a Vinyl File Stream:
@@ -118,11 +120,12 @@ function getNewContent(target, collection, opt) {
   var startAndEndTags = Object.keys(filesPerTags);
   var matches = [];
   var injectedFilesCount = 0;
-
+	
   startAndEndTags.forEach(function (tagKey) {
     var files = filesPerTags[tagKey];
     var startTag = files[0].startTag;
     var endTag = files[0].endTag;
+	  
     var tagsToInject = getTagsToInject(files, target, opt);
     content = inject(content, {
       startTag: startTag,
@@ -272,7 +275,7 @@ function makeWhiteSpaceOptional(str) {
 function getTagsToInject(files, target, opt) {
   return files.reduce(function transformFile(lines, file, i, files) {
     var filepath = getFilepath(file.file, target, opt);
-    var transformedContents = opt.transform(filepath, file.file, i, files.length, target);
+    var transformedContents = opt.transform(filepath, opt.attributes ,file.file, i, files.length, target);
     if (typeof transformedContents !== 'string') {
       return lines;
     }

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -50,7 +50,7 @@ module.exports = exports = function (sources, opt) {
   opt.transform = defaults(opt, 'transform', transform);
   opt.tags = tags();
   opt.name = defaults(opt, 'name', DEFAULT_NAME_FOR_TAGS);
-  opt.attributes = defaults(opt, 'attributes', []);
+  opt.attributes = defaults(opt, 'attributes', null);
   
   transform.selfClosingTag = bool(opt, 'selfClosingTag', false);
 

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -60,6 +60,18 @@ describe('gulp-inject', function () {
 
     streamShouldContain(stream, ['defaults.html'], done);
   });
+	
+  it('should inject stylesheets and scripts components into desired file with attributes', function (done) {
+    var target = src(['template.html'], {read: true});
+    var sources = src([
+      'lib.js',
+      'styles.css'
+	]);
+
+    var stream = target.pipe(inject(sources, {attributes: 'test'}));
+
+    streamShouldContain(stream, ['attributes.html'], done);
+  });
 
   it('should inject sources into multiple targets', function (done) {
     var target = src(['template.html', 'template2.html'], {read: true});
@@ -238,171 +250,171 @@ describe('gulp-inject', function () {
     streamShouldContain(stream, ['existingData.html'], done);
   });
 
-  it('should use custom transform function for each file if specified', function (done) {
-    var target = src(['template.json'], {read: true});
-    var sources = src([
-      'lib.js',
-      'component.html',
-      'lib2.js',
-      'styles.css'
-    ]);
+//  it('should use custom transform function for each file if specified', function (done) {
+//    var target = src(['template.json'], {read: true});
+//    var sources = src([
+//      'lib.js',
+//      'component.html',
+//      'lib2.js',
+//      'styles.css'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources, {
+//      ignorePath: 'fixtures',
+//      starttag: '"{{ext}}": [',
+//      endtag: ']',
+//      transform: function (srcPath, file, i, length) {
+//        return '  "' + srcPath + '"' + (i + 1 < length ? ',' : '');
+//      }
+//    }));
+//
+//    streamShouldContain(stream, ['customTransform.json'], done);
+//  });
 
-    var stream = target.pipe(inject(sources, {
-      ignorePath: 'fixtures',
-      starttag: '"{{ext}}": [',
-      endtag: ']',
-      transform: function (srcPath, file, i, length) {
-        return '  "' + srcPath + '"' + (i + 1 < length ? ',' : '');
-      }
-    }));
+//  it('should use special default tags when injecting into jsx files', function (done) {
+//    var target = src(['template.jsx'], {read: true});
+//    var sources = src([
+//      'lib.js',
+//      'component.html',
+//      'styles.css'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['defaults.jsx'], done);
+//  });
 
-    streamShouldContain(stream, ['customTransform.json'], done);
-  });
+//  it('should use special default tags when injecting into jade files', function (done) {
+//    var target = src(['template.jade'], {read: true});
+//    var sources = src([
+//      'lib.js',
+//      'component.html',
+//      'styles.css'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['defaults.jade'], done);
+//  });
 
-  it('should use special default tags when injecting into jsx files', function (done) {
-    var target = src(['template.jsx'], {read: true});
-    var sources = src([
-      'lib.js',
-      'component.html',
-      'styles.css'
-    ]);
+//  it('should use special default tags when injecting into pug files', function (done) {
+//    var target = src(['template.pug'], {read: true});
+//    var sources = src([
+//      'lib.js',
+//      'component.html',
+//      'styles.css'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['defaults.pug'], done);
+//  });
 
-    var stream = target.pipe(inject(sources));
+//  it('should be able to inject jsx into jade files (Issue #144)', function (done) {
+//    var target = src(['issue144.jade'], {read: true});
+//    var sources = src([
+//      'lib.js',
+//      'component.jsx'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['issue144.jade'], done);
+//  });
 
-    streamShouldContain(stream, ['defaults.jsx'], done);
-  });
+//  it('should be able to inject jsx into pug files (Issue #144)', function (done) {
+//    var target = src(['issue144.pug'], {read: true});
+//    var sources = src([
+//      'lib.js',
+//      'component.jsx'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['issue144.pug'], done);
+//  });
 
-  it('should use special default tags when injecting into jade files', function (done) {
-    var target = src(['template.jade'], {read: true});
-    var sources = src([
-      'lib.js',
-      'component.html',
-      'styles.css'
-    ]);
+//  it('should use special default tags when injecting into slm files', function (done) {
+//    var target = src(['template.slm'], {read: true});
+//    var sources = src([
+//      'lib.js',
+//      'component.html',
+//      'styles.css'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['defaults.slm'], done);
+//  });
 
-    var stream = target.pipe(inject(sources));
+//  it('should use special default tags when injecting into slim files', function (done) {
+//    var target = src(['template.slim'], {read: true});
+//    var sources = src([
+//      'lib.js',
+//      'component.html',
+//      'styles.css'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['defaults.slim'], done);
+//  });
 
-    streamShouldContain(stream, ['defaults.jade'], done);
-  });
+//  it('should use special default tags when injecting into haml files', function (done) {
+//    var target = src(['template.haml'], {read: true});
+//    var sources = src([
+//      'lib.js',
+//      'component.html',
+//      'styles.css'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['defaults.haml'], done);
+//  });
 
-  it('should use special default tags when injecting into pug files', function (done) {
-    var target = src(['template.pug'], {read: true});
-    var sources = src([
-      'lib.js',
-      'component.html',
-      'styles.css'
-    ]);
+//  it('should use special default tags when injecting into less files', function (done) {
+//    var target = src(['template.less'], {read: true});
+//    var sources = src([
+//      'lib.css',
+//      'component.less',
+//      'styles.less'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['defaults.less'], done);
+//  });
 
-    var stream = target.pipe(inject(sources));
+//  it('should use special default tags when injecting into sass files', function (done) {
+//    var target = src(['template.sass'], {read: true});
+//    var sources = src([
+//      'lib.css',
+//      'component.sass',
+//      'styles.sass',
+//      'component.scss',
+//      'styles.scss'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['defaults.sass'], done);
+//  });
 
-    streamShouldContain(stream, ['defaults.pug'], done);
-  });
-
-  it('should be able to inject jsx into jade files (Issue #144)', function (done) {
-    var target = src(['issue144.jade'], {read: true});
-    var sources = src([
-      'lib.js',
-      'component.jsx'
-    ]);
-
-    var stream = target.pipe(inject(sources));
-
-    streamShouldContain(stream, ['issue144.jade'], done);
-  });
-
-  it('should be able to inject jsx into pug files (Issue #144)', function (done) {
-    var target = src(['issue144.pug'], {read: true});
-    var sources = src([
-      'lib.js',
-      'component.jsx'
-    ]);
-
-    var stream = target.pipe(inject(sources));
-
-    streamShouldContain(stream, ['issue144.pug'], done);
-  });
-
-  it('should use special default tags when injecting into slm files', function (done) {
-    var target = src(['template.slm'], {read: true});
-    var sources = src([
-      'lib.js',
-      'component.html',
-      'styles.css'
-    ]);
-
-    var stream = target.pipe(inject(sources));
-
-    streamShouldContain(stream, ['defaults.slm'], done);
-  });
-
-  it('should use special default tags when injecting into slim files', function (done) {
-    var target = src(['template.slim'], {read: true});
-    var sources = src([
-      'lib.js',
-      'component.html',
-      'styles.css'
-    ]);
-
-    var stream = target.pipe(inject(sources));
-
-    streamShouldContain(stream, ['defaults.slim'], done);
-  });
-
-  it('should use special default tags when injecting into haml files', function (done) {
-    var target = src(['template.haml'], {read: true});
-    var sources = src([
-      'lib.js',
-      'component.html',
-      'styles.css'
-    ]);
-
-    var stream = target.pipe(inject(sources));
-
-    streamShouldContain(stream, ['defaults.haml'], done);
-  });
-
-  it('should use special default tags when injecting into less files', function (done) {
-    var target = src(['template.less'], {read: true});
-    var sources = src([
-      'lib.css',
-      'component.less',
-      'styles.less'
-    ]);
-
-    var stream = target.pipe(inject(sources));
-
-    streamShouldContain(stream, ['defaults.less'], done);
-  });
-
-  it('should use special default tags when injecting into sass files', function (done) {
-    var target = src(['template.sass'], {read: true});
-    var sources = src([
-      'lib.css',
-      'component.sass',
-      'styles.sass',
-      'component.scss',
-      'styles.scss'
-    ]);
-
-    var stream = target.pipe(inject(sources));
-
-    streamShouldContain(stream, ['defaults.sass'], done);
-  });
-
-  it('should use special default tags when injecting into scss files', function (done) {
-    var target = src(['template.scss'], {read: true});
-    var sources = src([
-      'lib.css',
-      'component.sass',
-      'styles.sass',
-      'component.scss',
-      'styles.scss'
-    ]);
-
-    var stream = target.pipe(inject(sources));
-
-    streamShouldContain(stream, ['defaults.scss'], done);
-  });
+//  it('should use special default tags when injecting into scss files', function (done) {
+//    var target = src(['template.scss'], {read: true});
+//    var sources = src([
+//      'lib.css',
+//      'component.sass',
+//      'styles.sass',
+//      'component.scss',
+//      'styles.scss'
+//    ]);
+//
+//    var stream = target.pipe(inject(sources));
+//
+//    streamShouldContain(stream, ['defaults.scss'], done);
+//  });
 
   it('should be able to chain inject calls with different names without overrides (Issue #39)', function (done) {
     var target = src(['issue39.html'], {read: true});

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -250,171 +250,171 @@ describe('gulp-inject', function () {
     streamShouldContain(stream, ['existingData.html'], done);
   });
 
-//  it('should use custom transform function for each file if specified', function (done) {
-//    var target = src(['template.json'], {read: true});
-//    var sources = src([
-//      'lib.js',
-//      'component.html',
-//      'lib2.js',
-//      'styles.css'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources, {
-//      ignorePath: 'fixtures',
-//      starttag: '"{{ext}}": [',
-//      endtag: ']',
-//      transform: function (srcPath, file, i, length) {
-//        return '  "' + srcPath + '"' + (i + 1 < length ? ',' : '');
-//      }
-//    }));
-//
-//    streamShouldContain(stream, ['customTransform.json'], done);
-//  });
+  it('should use custom transform function for each file if specified', function (done) {
+    var target = src(['template.json'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'lib2.js',
+      'styles.css'
+    ]);
 
-//  it('should use special default tags when injecting into jsx files', function (done) {
-//    var target = src(['template.jsx'], {read: true});
-//    var sources = src([
-//      'lib.js',
-//      'component.html',
-//      'styles.css'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['defaults.jsx'], done);
-//  });
+    var stream = target.pipe(inject(sources, {
+      ignorePath: 'fixtures',
+      starttag: '"{{ext}}": [',
+      endtag: ']',
+      transform: function (srcPath, arg, file, i, length) {
+        return '  "' + srcPath + '"' + (i + 1 < length ? ',' : '');
+      }
+    }));
 
-//  it('should use special default tags when injecting into jade files', function (done) {
-//    var target = src(['template.jade'], {read: true});
-//    var sources = src([
-//      'lib.js',
-//      'component.html',
-//      'styles.css'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['defaults.jade'], done);
-//  });
+    streamShouldContain(stream, ['customTransform.json'], done);
+  });
 
-//  it('should use special default tags when injecting into pug files', function (done) {
-//    var target = src(['template.pug'], {read: true});
-//    var sources = src([
-//      'lib.js',
-//      'component.html',
-//      'styles.css'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['defaults.pug'], done);
-//  });
+  it('should use special default tags when injecting into jsx files', function (done) {
+    var target = src(['template.jsx'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css'
+    ]);
 
-//  it('should be able to inject jsx into jade files (Issue #144)', function (done) {
-//    var target = src(['issue144.jade'], {read: true});
-//    var sources = src([
-//      'lib.js',
-//      'component.jsx'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['issue144.jade'], done);
-//  });
+    var stream = target.pipe(inject(sources));
 
-//  it('should be able to inject jsx into pug files (Issue #144)', function (done) {
-//    var target = src(['issue144.pug'], {read: true});
-//    var sources = src([
-//      'lib.js',
-//      'component.jsx'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['issue144.pug'], done);
-//  });
+    streamShouldContain(stream, ['defaults.jsx'], done);
+  });
 
-//  it('should use special default tags when injecting into slm files', function (done) {
-//    var target = src(['template.slm'], {read: true});
-//    var sources = src([
-//      'lib.js',
-//      'component.html',
-//      'styles.css'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['defaults.slm'], done);
-//  });
+  it('should use special default tags when injecting into jade files', function (done) {
+    var target = src(['template.jade'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css'
+    ]);
 
-//  it('should use special default tags when injecting into slim files', function (done) {
-//    var target = src(['template.slim'], {read: true});
-//    var sources = src([
-//      'lib.js',
-//      'component.html',
-//      'styles.css'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['defaults.slim'], done);
-//  });
+    var stream = target.pipe(inject(sources));
 
-//  it('should use special default tags when injecting into haml files', function (done) {
-//    var target = src(['template.haml'], {read: true});
-//    var sources = src([
-//      'lib.js',
-//      'component.html',
-//      'styles.css'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['defaults.haml'], done);
-//  });
+    streamShouldContain(stream, ['defaults.jade'], done);
+  });
 
-//  it('should use special default tags when injecting into less files', function (done) {
-//    var target = src(['template.less'], {read: true});
-//    var sources = src([
-//      'lib.css',
-//      'component.less',
-//      'styles.less'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['defaults.less'], done);
-//  });
+  it('should use special default tags when injecting into pug files', function (done) {
+    var target = src(['template.pug'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css'
+    ]);
 
-//  it('should use special default tags when injecting into sass files', function (done) {
-//    var target = src(['template.sass'], {read: true});
-//    var sources = src([
-//      'lib.css',
-//      'component.sass',
-//      'styles.sass',
-//      'component.scss',
-//      'styles.scss'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['defaults.sass'], done);
-//  });
+    var stream = target.pipe(inject(sources));
 
-//  it('should use special default tags when injecting into scss files', function (done) {
-//    var target = src(['template.scss'], {read: true});
-//    var sources = src([
-//      'lib.css',
-//      'component.sass',
-//      'styles.sass',
-//      'component.scss',
-//      'styles.scss'
-//    ]);
-//
-//    var stream = target.pipe(inject(sources));
-//
-//    streamShouldContain(stream, ['defaults.scss'], done);
-//  });
+    streamShouldContain(stream, ['defaults.pug'], done);
+  });
+
+  it('should be able to inject jsx into jade files (Issue #144)', function (done) {
+    var target = src(['issue144.jade'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.jsx'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    streamShouldContain(stream, ['issue144.jade'], done);
+  });
+
+  it('should be able to inject jsx into pug files (Issue #144)', function (done) {
+    var target = src(['issue144.pug'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.jsx'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    streamShouldContain(stream, ['issue144.pug'], done);
+  });
+
+  it('should use special default tags when injecting into slm files', function (done) {
+    var target = src(['template.slm'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    streamShouldContain(stream, ['defaults.slm'], done);
+  });
+
+  it('should use special default tags when injecting into slim files', function (done) {
+    var target = src(['template.slim'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    streamShouldContain(stream, ['defaults.slim'], done);
+  });
+
+  it('should use special default tags when injecting into haml files', function (done) {
+    var target = src(['template.haml'], {read: true});
+    var sources = src([
+      'lib.js',
+      'component.html',
+      'styles.css'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    streamShouldContain(stream, ['defaults.haml'], done);
+  });
+
+  it('should use special default tags when injecting into less files', function (done) {
+    var target = src(['template.less'], {read: true});
+    var sources = src([
+      'lib.css',
+      'component.less',
+      'styles.less'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    streamShouldContain(stream, ['defaults.less'], done);
+  });
+
+  it('should use special default tags when injecting into sass files', function (done) {
+    var target = src(['template.sass'], {read: true});
+    var sources = src([
+      'lib.css',
+      'component.sass',
+      'styles.sass',
+      'component.scss',
+      'styles.scss'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    streamShouldContain(stream, ['defaults.sass'], done);
+  });
+
+  it('should use special default tags when injecting into scss files', function (done) {
+    var target = src(['template.scss'], {read: true});
+    var sources = src([
+      'lib.css',
+      'component.sass',
+      'styles.sass',
+      'component.scss',
+      'styles.scss'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    streamShouldContain(stream, ['defaults.scss'], done);
+  });
 
   it('should be able to chain inject calls with different names without overrides (Issue #39)', function (done) {
     var target = src(['issue39.html'], {read: true});

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -56,8 +56,8 @@ transform.html.js = function (filepath, attributes) {
 };
 transform.html.map = transform.html.js;
 
-transform.html.jsx = function (filepath) {
-  return '<script type="text/jsx" src="' + filepath + '"></script>';
+transform.html.jsx = function (filepath, attributes) {
+  return '<script type="text/jsx" src="' + filepath + '"' + attrString(attributes) + '></script>';
 };
 
 transform.html.html = function (filepath) {

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var extname = require('../extname');
+var attrString = require('../attrString');
 
 /**
  * Constants
@@ -11,7 +12,7 @@ var DEFAULT_TARGET = TARGET_TYPES[0];
 /**
  * Transform module
  */
-var transform = module.exports = exports = function (filepath, i, length, sourceFile, targetFile) {
+var transform = module.exports = exports = function (filepath, attributes , i, length, sourceFile, targetFile) {
   var type;
   if (targetFile && targetFile.path) {
     var ext = extname(targetFile.path);
@@ -36,7 +37,7 @@ transform.selfClosingTag = false;
  * Transform functions
  */
 TARGET_TYPES.forEach(function (targetType) {
-  transform[targetType] = function (filepath) {
+  transform[targetType] = function (filepath, attributes) {
     var ext = extname(filepath);
     var type = typeFromExt(ext);
     var func = transform[targetType][type];
@@ -46,12 +47,12 @@ TARGET_TYPES.forEach(function (targetType) {
   };
 });
 
-transform.html.css = function (filepath) {
-  return '<link rel="stylesheet" href="' + filepath + '"' + end();
+transform.html.css = function (filepath, attributes) {
+  return '<link rel="stylesheet" href="' + filepath + '"' + attrString(attributes) + end();
 };
 
-transform.html.js = function (filepath) {
-  return '<script src="' + filepath + '"></script>';
+transform.html.js = function (filepath, attributes) {
+  return '<script src="' + filepath + '"' + attrString(attributes) + '></script>';
 };
 transform.html.map = transform.html.js;
 

--- a/src/transform/index.js
+++ b/src/transform/index.js
@@ -60,16 +60,16 @@ transform.html.jsx = function (filepath, attributes) {
   return '<script type="text/jsx" src="' + filepath + '"' + attrString(attributes) + '></script>';
 };
 
-transform.html.html = function (filepath) {
-  return '<link rel="import" href="' + filepath + '"' + end();
+transform.html.html = function (filepath, attributes) {
+  return '<link rel="import" href="' + filepath + '"' + attrString(attributes) + end();
 };
 
-transform.html.coffee = function (filepath) {
-  return '<script type="text/coffeescript" src="' + filepath + '"></script>';
+transform.html.coffee = function (filepath, attributes) {
+  return '<script type="text/coffeescript" src="' + filepath + '"' + attrString(attributes) + '></script>';
 };
 
-transform.html.image = function (filepath) {
-  return '<img src="' + filepath + '"' + end();
+transform.html.image = function (filepath, attributes) {
+  return '<img src="' + filepath + '"' + attrString(attributes) + end();
 };
 
 transform.jade.css = function (filepath) {

--- a/src/transform/transform_test.js
+++ b/src/transform/transform_test.js
@@ -127,13 +127,32 @@ describe('transform', function () {
       transform.html('test-file.jpg').should.equal(transform.html.image('test-file.jpg'));
       transform.html('test-file.jpeg').should.equal(transform.html.image('test-file.jpeg'));
     });
-	  
-	it('should transform css to a link tag with attributes', function () {
-      transform.html.css('test-file.css', 'test').should.equal('<link rel="stylesheet" href="test-file.css" test>');
-    });
-    it('should transform javascript to a script tag with attributes', function () {
+  
+	describe('with attributes', function(){
+		it('should transform javascript to a script tag', function () {
       transform.html.js('test-file.js', 'test').should.equal('<script src="test-file.js" test></script>');
     });
+	  it('should transform css to a link tag', function () {
+      transform.html.css('test-file.css', 'test').should.equal('<link rel="stylesheet" href="test-file.css" test>');
+    });
+
+    it('should transform html to a link tag', function () {
+      transform.html.html('test-file.html', 'test').should.equal('<link rel="import" href="test-file.html" test>');
+    });
+
+    it('should transform jsx to a script tag', function () {
+      transform.html.jsx('test-file.jsx', 'test').should.equal('<script type="text/jsx" src="test-file.jsx" test></script>');
+    });
+
+    it('should transform coffeescript to a script tag', function () {
+      transform.html.coffee('test-file.coffee', 'test').should.equal('<script type="text/coffeescript" src="test-file.coffee" test></script>');
+    });
+
+    it('should transform an image to an img tag', function () {
+      transform.html.image('test-file.png', 'test').should.equal('<img src="test-file.png" test>');
+    });
+	});  
+
   });
 
   describe('jsx as target', function () {
@@ -485,63 +504,63 @@ describe('transform', function () {
   it('should pick the correct target transformer for html targets', function () {
     var targetFile = fixture('index.html');
     var sourceFile = fixture('style.css');
-    transform(sourceFile.path, null, null, sourceFile, targetFile)
+    transform(sourceFile.path, null, null, null, sourceFile, targetFile)
       .should.equal(transform.html.css(sourceFile.path));
   });
 
   it('should pick the correct target transformer for jsx targets', function () {
     var targetFile = fixture('app.jsx');
     var sourceFile = fixture('app.js');
-    transform(sourceFile.path, null, null, sourceFile, targetFile)
+    transform(sourceFile.path, null, null, null, sourceFile, targetFile)
       .should.equal(transform.jsx.js(sourceFile.path));
   });
 
   it('should pick the correct target transformer for jade targets', function () {
     var targetFile = fixture('index.jade');
     var sourceFile = fixture('image.gif');
-    transform(sourceFile.path, null, null, sourceFile, targetFile)
+    transform(sourceFile.path, null, null, null, sourceFile, targetFile)
       .should.equal(transform.jade.image(sourceFile.path));
   });
 
   it('should pick the correct target transformer for pug targets', function () {
     var targetFile = fixture('index.pug');
     var sourceFile = fixture('image.gif');
-    transform(sourceFile.path, null, null, sourceFile, targetFile)
+    transform(sourceFile.path, null, null, null, sourceFile, targetFile)
       .should.equal(transform.pug.image(sourceFile.path));
   });
 
   it('should pick the correct target transformer for slm targets', function () {
     var targetFile = fixture('index.slm');
     var sourceFile = fixture('image.gif');
-    transform(sourceFile.path, null, null, sourceFile, targetFile)
+    transform(sourceFile.path, null, null, null, sourceFile, targetFile)
       .should.equal(transform.slm.image(sourceFile.path));
   });
 
   it('should pick the correct target transformer for haml targets', function () {
     var targetFile = fixture('index.haml');
     var sourceFile = fixture('image.gif');
-    transform(sourceFile.path, null, null, sourceFile, targetFile)
+    transform(sourceFile.path, null, null, null, sourceFile, targetFile)
       .should.equal(transform.haml.image(sourceFile.path));
   });
 
   it('should pick the correct target transformer for less targets', function () {
     var targetFile = fixture('index.less');
     var sourceFile = fixture('test-file.less');
-    transform(sourceFile.path, null, null, sourceFile, targetFile)
+    transform(sourceFile.path, null, null, null, sourceFile, targetFile)
       .should.equal(transform.less.less(sourceFile.path));
   });
 
   it('should pick the correct target transformer for sass targets', function () {
     var targetFile = fixture('index.sass');
     var sourceFile = fixture('test-file.sass');
-    transform(sourceFile.path, null, null, sourceFile, targetFile)
+    transform(sourceFile.path, null, null, null, sourceFile, targetFile)
       .should.equal(transform.sass.sass(sourceFile.path));
   });
 
   it('should pick the correct target transformer for scss targets', function () {
     var targetFile = fixture('index.scss');
     var sourceFile = fixture('test-file.scss');
-    transform(sourceFile.path, null, null, sourceFile, targetFile)
+    transform(sourceFile.path, null, null, null, sourceFile, targetFile)
       .should.equal(transform.scss.scss(sourceFile.path));
   });
 

--- a/src/transform/transform_test.js
+++ b/src/transform/transform_test.js
@@ -127,6 +127,13 @@ describe('transform', function () {
       transform.html('test-file.jpg').should.equal(transform.html.image('test-file.jpg'));
       transform.html('test-file.jpeg').should.equal(transform.html.image('test-file.jpeg'));
     });
+	  
+	it('should transform css to a link tag with attributes', function () {
+      transform.html.css('test-file.css', 'test').should.equal('<link rel="stylesheet" href="test-file.css" test>');
+    });
+    it('should transform javascript to a script tag with attributes', function () {
+      transform.html.js('test-file.js', 'test').should.equal('<script src="test-file.js" test></script>');
+    });
   });
 
   describe('jsx as target', function () {


### PR DESCRIPTION
In order to use this plugin together with other gulp-plugins such as for example `gulp-inline-source`, added an option called `attributes` which adds the specified attributes to the corresponding html tags.

The attributes can be 
* a string (the string is added as a attribute (suitable for `gulp-inline-source`: `attributes: 'inline'`))
* an object (`{a: 'A', b: 'B'}` leads to ` a="A" b="B"`) 
* an array of
  * strings: ( `['a', 'b']`  -> `a b`)
  * objects ( `[{name: 'a', value:'A'}, {name: 'b', value:'B'}]`  -> `a="A" b="B"` )
  * arrays ( `[['a', 'A'],['b', 'B']]`  -> `a="A" b="B"`)

Tests for this feature are added too.

Please let me know if I should make some additional changes. For example specifying attributes to special files.