### PR TITLE
chore: Log the correct plural state of the number of injected files

### DIFF
--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -106,7 +106,8 @@ function handleVinylStream(sources, opt) {
 function getNewContent(target, collection, opt) {
   var logger = opt.quiet ? noop : function (filesCount) {
     if (filesCount) {
-      log(cyan(filesCount) + ' files into ' + magenta(target.relative) + '.');
+      var pluralState = filesCount > 1 ? 's' : '';
+      log(cyan(filesCount) + ' file' + pluralState + ' into ' + magenta(target.relative) + '.');
     } else {
       log('Nothing to inject into ' + magenta(target.relative) + '.');
     }

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -562,7 +562,32 @@ describe('gulp-inject', function () {
 
     stream.on('end', function () {
       logOutput.should.have.length(1);
-      stripColor(logOutput[0]).should.equal('gulp-inject 1 files into template2.html.');
+      stripColor(logOutput[0]).should.equal('gulp-inject 1 file into template2.html.');
+      done();
+    });
+  });
+
+  it('should produce log output for multiple files actually injected (issue #192)', function (done) {
+    var logOutput = [];
+    gutil.log = function (a, b) {
+      logOutput.push(a + ' ' + b);
+    };
+
+    var target = src(['template2.html'], {read: true});
+    var sources = src([
+      'styles.css',
+      'app.css'
+    ]);
+
+    var stream = target.pipe(inject(sources));
+
+    // Dummy data reader to make the `end` event be triggered
+    stream.on('data', function () {
+    });
+
+    stream.on('end', function () {
+      logOutput.should.have.length(1);
+      stripColor(logOutput[0]).should.equal('gulp-inject 2 files into template2.html.');
       done();
     });
   });


### PR DESCRIPTION
Currently, the logged message on the number of injected files is statically set to plural state.

<img width="415" alt="screen shot 2016-07-21 at 2 45 46 pm" src="https://cloud.githubusercontent.com/assets/16223627/17021625/dd8c0710-4f51-11e6-9a66-2d67a6033b71.png">

It would make sense to have the message reflect the correct plural state of the `filesCount` variable.

``` js
   if (filesCount) {
      var pluralState = filesCount > 1 ? 's' : '';
      log(cyan(filesCount) + ' file' + pluralState + ' into ' + magenta(target.relative) + '.');
    } else {
      log('Nothing to inject into ' + magenta(target.relative) + '.');
    }
```

This would look something like this.

<img width="410" alt="screen shot 2016-07-21 at 2 47 34 pm" src="https://cloud.githubusercontent.com/assets/16223627/17021670/2a94736c-4f52-11e6-9e90-041921ed7b6b.png">
