### PR TITLE
add definitions of "gulp-concat" and "gulp-uglify"

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,9 @@ Install [`event-stream`](https://www.npmjs.org/package/event-stream) with: `npm 
 
 ```javascript
 var es = require('event-stream'),
-    inject = require('gulp-inject');
+    inject = require('gulp-inject'),
+    concat = require('gulp-concat'),
+    uglify = require('gulp-uglify');
 
 // Concatenate vendor scripts
 var vendorStream = gulp.src(['./src/vendors/*.js'])


### PR DESCRIPTION
add definitions of "gulp-concat" and "gulp-uglify" for the example that demonstrates how to inject files from multiple different streams into the same injection placeholder.