### PR TITLE
fix (#224): fix endtag default

### DIFF
--- a/src/inject/expected/emptyTags3.html
+++ b/src/inject/expected/emptyTags3.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- inject:html -->
+  <!-- endinject -->
+  <!-- inject:css -->
+  <!-- endinject -->
+</head>
+<body>
+  <!-- inject:png -->
+  <img src="my-image.png" alt="">
+  <!-- endinject -->
+
+  <!-- inject:js -->
+  <!-- endinject -->
+
+  <!-- custominject -->
+  <!-- endcustominject -->
+
+</body>
+</html>

--- a/src/inject/fixtures/templateWithExistingData3.html
+++ b/src/inject/fixtures/templateWithExistingData3.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- inject:html -->
+  <!-- endinject -->
+  <!-- inject:css -->
+  <!-- endinject -->
+</head>
+<body>
+  <!-- inject:png -->
+  <img src="my-image.png" alt="">
+  <!-- endinject -->
+
+  <!-- inject:js -->
+  <!-- endinject -->
+
+  <!-- custominject -->
+  <img src="my-image.png" alt="">
+  <!-- endcustominject -->
+
+</body>
+</html>

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -144,7 +144,7 @@ function getNewContent(target, collection, opt) {
   if (opt.empty) {
     var ext = '{{ANY}}';
     var startTag = getTagRegExp(opt.tags.start(targetExt, ext, opt.starttag), ext, opt);
-    var endTag = getTagRegExp(opt.tags.end(targetExt, ext, opt.starttag), ext, opt);
+    var endTag = getTagRegExp(opt.tags.end(targetExt, ext, opt.endtag), ext, opt);
 
     content = inject(content, {
       startTag: startTag,

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -666,6 +666,15 @@ describe('gulp-inject', function () {
 
     streamShouldContain(stream, ['removeAndEmptyTags.html'], done);
   });
+
+  it('should be able to empty custom tags when there are no files at all and empty option is set', function (done) {
+    var target = src(['templateWithExistingData3.html'], {read: true});
+    var sources = src([]);
+
+    var stream = target.pipe(inject(sources, {empty: true, starttag: '<!-- custominject -->', endtag: '<!-- endcustominject -->'}));
+
+    streamShouldContain(stream, ['emptyTags3.html'], done);
+  });
 });
 
 function src(files, opt) {


### PR DESCRIPTION
- change call to opt.tags.end in getNewContent to use endtag as the default, rather than starttag
- add unit test for emptying custom tags
- unit tests passing

Fixes: #224