### PR TITLE
chore: drop dependency on deprecated `gulp-util`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,16 @@
     "pretest": "npm run -s lint",
     "test": "mocha -R spec src/**/*_test.js",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-		"commitmsg": "commitlint -e"
+    "commitmsg": "commitlint -e"
   },
   "dependencies": {
+    "ansi-colors": "^1.0.1",
     "arrify": "^1.0.1",
     "escape-string-regexp": "^1.0.5",
     "event-stream": "^3.1.0",
+    "fancy-log": "^1.3.2",
     "group-array": "^0.3.0",
-    "gulp-util": "^3.0.0",
+    "plugin-error": "^0.1.2",
     "stream-to-array": "^2.3.0",
     "through2": "^2.0.1"
   },
@@ -46,6 +48,7 @@
     "semantic-release": "^7.0.2",
     "should": "^4.0.4",
     "strip-color": "^0.1.0",
+    "vinyl": "^2.1.0",
     "xo": "^0.13.0"
   },
   "engines": {

--- a/src/inject/index.js
+++ b/src/inject/index.js
@@ -1,6 +1,8 @@
 'use strict';
 var through2 = require('through2');
-var gutil = require('gulp-util');
+var fancyLog = require('fancy-log');
+var PluginError = require('plugin-error');
+var colors = require('ansi-colors');
 var streamToArray = require('stream-to-array');
 var escapeStringRegexp = require('escape-string-regexp');
 var groupArray = require('group-array');
@@ -9,9 +11,8 @@ var transform = require('../transform');
 var tags = require('../tags');
 var getFilepath = require('../path');
 
-var PluginError = gutil.PluginError;
-var magenta = gutil.colors.magenta;
-var cyan = gutil.colors.cyan;
+var magenta = colors.magenta;
+var cyan = colors.cyan;
 var noop = function noop() {};
 
 /**
@@ -284,7 +285,7 @@ function getTagsToInject(files, target, opt) {
 }
 
 function log(message) {
-  gutil.log(magenta(PLUGIN_NAME), message);
+  fancyLog.info(magenta(PLUGIN_NAME), message);
 }
 
 function error(message) {

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -5,7 +5,8 @@ var fs = require('fs');
 var path = require('path');
 var es = require('event-stream');
 var should = require('should');
-var gutil = require('gulp-util');
+var fancyLog = require('fancy-log');
+var Vinyl = require('vinyl');
 var stripColor = require('strip-color');
 var inject = require('../../.');
 
@@ -13,11 +14,11 @@ describe('gulp-inject', function () {
   var log;
 
   beforeEach(function () {
-    log = gutil.log;
+    log = fancyLog.info;
   });
 
   afterEach(function () {
-    gutil.log = log;
+    fancyLog.info = log;
   });
 
   it('should throw an error when the old api with target as string is used', function () {
@@ -509,7 +510,7 @@ describe('gulp-inject', function () {
 
   it('should not produce log output if quiet option is set', function (done) {
     var logOutput = [];
-    gutil.log = function () {
+    fancyLog.info = function () {
       logOutput.push(arguments);
     };
 
@@ -535,7 +536,7 @@ describe('gulp-inject', function () {
 
   it('should produce log output if quiet option is not set', function (done) {
     var logOutput = [];
-    gutil.log = function () {
+    fancyLog.info = function () {
       logOutput.push(arguments);
     };
 
@@ -561,7 +562,7 @@ describe('gulp-inject', function () {
 
   it('should produce log output only for files actually injected (issue #184)', function (done) {
     var logOutput = [];
-    gutil.log = function (a, b) {
+    fancyLog.info = function (a, b) {
       logOutput.push(a + ' ' + b);
     };
 
@@ -588,7 +589,7 @@ describe('gulp-inject', function () {
 
   it('should produce log output for multiple files actually injected (issue #192)', function (done) {
     var logOutput = [];
-    gutil.log = function (a, b) {
+    fancyLog.info = function (a, b) {
       logOutput.push(a + ' ' + b);
     };
 
@@ -740,7 +741,7 @@ function streamShouldContain(stream, files, done) {
 
 function expectedFile(file) {
   var filepath = path.resolve(__dirname, 'expected', file);
-  return new gutil.File({
+  return new Vinyl({
     path: filepath,
     cwd: __dirname,
     base: path.resolve(__dirname, 'expected', path.dirname(file)),
@@ -750,7 +751,7 @@ function expectedFile(file) {
 
 function fixture(file, read) {
   var filepath = path.resolve(__dirname, 'fixtures', file);
-  return new gutil.File({
+  return new Vinyl({
     path: filepath,
     cwd: __dirname,
     base: path.resolve(__dirname, 'fixtures', path.dirname(file)),

--- a/src/path/path_test.js
+++ b/src/path/path_test.js
@@ -1,14 +1,14 @@
 /* eslint-env mocha */
 'use strict';
 var path = require('path');
-var File = require('gulp-util').File;
+var Vinyl = require('vinyl');
 require('should');
 var getFilepath = require('./');
 
 describe('getFilepath', function () {
   describe('(relative=false)', function () {
     it('returns the path relative to the source file\'s cwd', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir', 'file.js'),
         base: path.join(__dirname, 'dir')
@@ -19,7 +19,7 @@ describe('getFilepath', function () {
     });
 
     it('returns the unixified path relative to the source file\'s cwd', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: 'C:\\a\\folder',
         path: 'C:\\a\\folder\\dir\\file.js',
         base: 'C:\\a\\folder\\dir'
@@ -32,12 +32,12 @@ describe('getFilepath', function () {
 
   describe('(relative=true)', function () {
     it('returns the path relative to the target file\'s directory', function () {
-      var target = new File({
+      var target = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir1', 'index.html'),
         base: path.join(__dirname, 'dir1')
       });
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir2', 'file.js'),
         base: path.join(__dirname, 'dir2')
@@ -48,12 +48,12 @@ describe('getFilepath', function () {
     });
 
     it('returns the unixified path relative to the source file\'s cwd', function () {
-      var target = new File({
+      var target = new Vinyl({
         cwd: 'C:\\a\\folder',
         path: 'C:\\a\\folder\\dir1\\index.html',
         base: 'C:\\a\\folder\\dir1'
       });
-      var source = new File({
+      var source = new Vinyl({
         cwd: 'C:\\a\\folder',
         path: 'C:\\a\\folder\\dir2\\file.js',
         base: 'C:\\a\\folder\\dir2'
@@ -66,7 +66,7 @@ describe('getFilepath', function () {
 
   describe('(ignorePath)', function () {
     it('removes the provided `ignorePath` from the beginning of the path', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir', 'file.js'),
         base: path.join(__dirname, 'dir')
@@ -77,7 +77,7 @@ describe('getFilepath', function () {
     });
 
     it('removes the provided `ignorePath` even if it both begins and ends in a `/` from the beginning of the path', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir', 'file.js'),
         base: path.join(__dirname, 'dir')
@@ -88,7 +88,7 @@ describe('getFilepath', function () {
     });
 
     it('removes the provided `ignorePath`s from the beginning of the path', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir', 'file.js'),
         base: path.join(__dirname, 'dir')
@@ -99,7 +99,7 @@ describe('getFilepath', function () {
     });
 
     it('removes the provided `ignorePath` unixified from the beginning of the path', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir', 'deep', 'file.js'),
         base: path.join(__dirname, 'dir', 'deep')
@@ -110,7 +110,7 @@ describe('getFilepath', function () {
     });
 
     it('removes the provided `ignorePath` unixified from the beginning of a unixified path', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: 'C:\\a\\folder',
         path: 'C:\\a\\folder\\dir\\deep\\file.js',
         base: 'C:\\a\\folder\\dir\\deep'
@@ -121,7 +121,7 @@ describe('getFilepath', function () {
     });
 
     it('removes the provided `ignorePath` from the beginning of a unixified path', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: 'C:\\a\\folder',
         path: 'C:\\a\\folder\\dir\\deep\\file.js',
         base: 'C:\\a\\folder\\dir\\deep'
@@ -134,7 +134,7 @@ describe('getFilepath', function () {
 
   describe('(addRootSlash=true)', function () {
     it('prepends the path with a `/`', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir', 'file.js'),
         base: path.join(__dirname, 'dir')
@@ -147,7 +147,7 @@ describe('getFilepath', function () {
 
   describe('(addPrefix)', function () {
     it('prepends the prefix and a `/` to the path', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir', 'file.js'),
         base: path.join(__dirname, 'dir')
@@ -158,7 +158,7 @@ describe('getFilepath', function () {
     });
 
     it('keeps any leading `/` from the prefix', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir', 'file.js'),
         base: path.join(__dirname, 'dir')
@@ -171,7 +171,7 @@ describe('getFilepath', function () {
 
   describe('(addSuffix)', function () {
     it('appends the suffix to the path', function () {
-      var source = new File({
+      var source = new Vinyl({
         cwd: __dirname,
         path: path.join(__dirname, 'dir', 'file.js'),
         base: path.join(__dirname, 'dir')

--- a/src/transform/transform_test.js
+++ b/src/transform/transform_test.js
@@ -3,7 +3,7 @@
 var path = require('path');
 var fs = require('fs');
 var should = require('should');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 
 describe('transform', function () {
   var transform;
@@ -554,7 +554,7 @@ describe('transform', function () {
 
 function fixture(file, read) {
   var filepath = path.resolve(__dirname, 'fixtures', file);
-  return new gutil.File({
+  return new Vinyl({
     path: filepath,
     cwd: __dirname,
     base: path.resolve(__dirname, 'fixtures', path.dirname(file)),


### PR DESCRIPTION
Closes #235 