### PR TITLE
Option to allow single tag (no end tag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 [![NPM version][npm-image]][npm-url] [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![Build Status][travis-image]][travis-url] [![XO code style][codestyle-image]][codestyle-url] [![Dependency Status][depstat-image]][depstat-url]
 
-> A stylesheet, javascript and webcomponent reference injection plugin for [gulp](https://github.com/wearefractal/gulp). No more manual editing of your index.html!
+> A stylesheet, javascript and webcomponent reference or content injection plugin for [gulp](https://github.com/wearefractal/gulp). No more manual editing of your index.html!
 
 # Contents
 
@@ -50,6 +50,7 @@
       - [options.addRootSlash](#optionsaddrootslash)   
       - [options.name](#optionsname)   
       - [options.removeTags](#optionsremovetags)   
+      - [options.singleTag](#optionssingletag)   
       - [options.empty](#optionsempty)   
       - [options.starttag](#optionsstarttag)   
       - [options.endtag](#optionsendtag)   
@@ -699,6 +700,14 @@ Default: `false`
 
 
 When `true` the start and end tags will be removed when injecting files.
+
+#### options.singleTag
+Type: `Boolean`
+
+Default: `false`
+
+
+When `true` an end tag will be neither required nor expected.
 
 #### options.empty
 Type: `Boolean`

--- a/src/inject/expected/singleTag.html
+++ b/src/inject/expected/singleTag.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- inject:css -->
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <!-- inject:js -->
+  <script src="/lib.js"></script>
+  <script src="/lib2.js"></script>
+</body>
+</html>

--- a/src/inject/expected/singleTagMultiple.html
+++ b/src/inject/expected/singleTagMultiple.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <script>
+    let css = '<link rel="stylesheet" href="/style.css">'
+  </script>
+</body>
+</html>

--- a/src/inject/expected/singleTagRemoveTags.html
+++ b/src/inject/expected/singleTagRemoveTags.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body>
+  <script src="/lib.js"></script>
+  <script src="/lib2.js"></script>
+</body>
+</html>

--- a/src/inject/fixtures/templateSingleTag.html
+++ b/src/inject/fixtures/templateSingleTag.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- inject:css -->
+</head>
+<body>
+  <!-- inject:js -->
+</body>
+</html>

--- a/src/inject/fixtures/templateSingleTagMultiple.html
+++ b/src/inject/fixtures/templateSingleTagMultiple.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>gulp-inject</title>
+  <!-- inject:css -->
+</head>
+<body>
+  <script>
+    let css = '<!-- inject:css -->'
+  </script>
+</body>
+</html>

--- a/src/inject/inject_test.js
+++ b/src/inject/inject_test.js
@@ -194,6 +194,22 @@ describe('gulp-inject', function () {
     streamShouldContain(stream, ['customTags.html'], done);
   });
 
+  it('should require no endtag if `singleTag` is `true`', function (done) {
+    var target = src(['templateSingleTag.html'], {read: true});
+    var sources = src([
+      'lib.js',
+      'lib2.js',
+      'style.css'
+    ]);
+
+    var stream = target.pipe(inject(sources, {
+      ignorePath: 'fixtures',
+      singleTag: true
+    }));
+
+    streamShouldContain(stream, ['singleTag.html'], done);
+  });
+
   it('should use starttag and endtag with specified name if specified', function (done) {
     var target = src(['templateCustomName.html'], {read: true});
     var sources = src([
@@ -491,6 +507,23 @@ describe('gulp-inject', function () {
     streamShouldContain(stream, ['removeTags.html'], done);
   });
 
+  it('should remove tags if `singleTag` is `true` and `removeTags` is `true`', function (done) {
+    var target = src(['templateSingleTag.html'], {read: true});
+    var sources = src([
+      'lib.js',
+      'lib2.js',
+      'style.css'
+    ]);
+
+    var stream = target.pipe(inject(sources, {
+      ignorePath: 'fixtures',
+      singleTag: true,
+      removeTags: true
+    }));
+
+    streamShouldContain(stream, ['singleTagRemoveTags.html'], done);
+  });
+
   it('should be able to remove tags without removing whitespace (issue #177)', function (done) {
     var target = src(['template.html'], {read: true});
     var sources = src([
@@ -506,6 +539,21 @@ describe('gulp-inject', function () {
     var stream = target.pipe(inject(sources, {removeTags: true}));
 
     streamShouldContain(stream, ['issue177.html'], done);
+  });
+
+  it('should inject in multiple places (with `singleTag` = `true` and `removeTags` = `true`)', function (done) {
+    var target = src(['templateSingleTagMultiple.html'], {read: true});
+    var sources = src([
+      'style.css'
+    ]);
+
+    var stream = target.pipe(inject(sources, {
+      ignorePath: 'fixtures',
+      singleTag: true,
+      removeTags: true
+    }));
+
+    streamShouldContain(stream, ['singleTagMultiple.html'], done);
   });
 
   it('should not produce log output if quiet option is set', function (done) {


### PR DESCRIPTION
@joakimbeng, I'd like to extend to you my appreciation for writing this gulp plug-in.

I've got a project that uses gulp-inject, which injects CSS and JS contents into the HTML. I realized it would be nice to be able to omit the closing tag, to just have placeholders like this:

```html
<!DOCTYPE html>
<html>
<head>
  <title>Single file application</title>
  <!-- inject:css -->
</head>
<body>
  <!-- inject:js -->
</body>
</html>
```

This pull requests adds an option named `singleTag` which, if set to `true`, will no longer require a matching end tag.

If you would kindly take a look at this and consider merging it, I would love to switch to using a newer published version of gulp-inject with the ability to do this.

Also, if you don't mind, I might also like to contribute some refactoring improvements which could make it easier for people to make further contributions to this project.